### PR TITLE
Some search ads

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,9 @@ inbound.referrer.parse(url, referrer, function (err, description) {
 * [Hotmail](https://github.com/segmentio/inbound/tree/master/lib/matchers/email/hotmail.js)
 
 ### Ads
-_Gasp!_ None yet. Please [help me add some](#contribute).
+* [Bing](https://github.com/segmentio/inbound/tree/master/lib/matchers/ad/bing.js)
+* [Google](https://github.com/segmentio/inbound/tree/master/lib/matchers/ad/google.js)
+* [Yahoo](https://github.com/segmentio/inbound/tree/master/lib/matchers/ad/yahoo.js)
 
 ### Internal
 Internal referrers occur when a visitor navigates between two pages of the same domain. Example: http://site.com => http://site.com/about

--- a/lib/matchers/ad/bing.js
+++ b/lib/matchers/ad/bing.js
@@ -1,0 +1,16 @@
+
+var querystring = require('querystring');
+
+module.exports = function (href, referrer, callback) {
+
+  if (referrer.host && referrer.host.indexOf('bing.com') !== -1 &&
+      href.href.indexOf("utm_medium=cpc") !== -1) {
+    var description = { type: 'ad', network: 'bing' };
+    var query = querystring.parse(referrer.query).q;
+    if (query) description.query = query;
+    return callback(null, description);
+  } else {
+    return callback(null, false);
+  }
+
+};

--- a/lib/matchers/ad/google.js
+++ b/lib/matchers/ad/google.js
@@ -9,9 +9,7 @@ module.exports = function (href, referrer, callback) {
          
     var description = {
       type: 'ad',
-      client: 'google',
-      from: referrer.href,
-      link: href.href
+      network: 'google'
     };
     var query = querystring.parse(referrer.query).q;
     if (query) description.query = query;

--- a/lib/matchers/ad/google.js
+++ b/lib/matchers/ad/google.js
@@ -1,0 +1,24 @@
+var querystring = require("querystring");
+
+module.exports = function (href, referrer, callback) {
+
+  if (referrer.host && 
+      referrer.path.indexOf("/aclk") !== -1 &&
+      (referrer.host.indexOf('google.com') !== -1 ||
+       referrer.host.indexOf('googleadservices.com') !== -1)) {
+         
+    var description = {
+      type: 'ad',
+      client: 'google',
+      from: referrer.href,
+      link: href.href
+    };
+    var query = querystring.parse(referrer.query).q;
+    if (query) description.query = query;
+         
+    return callback(null, description);
+  } else {
+    return callback(null, false);
+  }
+
+};

--- a/lib/matchers/ad/yahoo.js
+++ b/lib/matchers/ad/yahoo.js
@@ -1,0 +1,16 @@
+
+var querystring = require('querystring');
+
+module.exports = function (href, referrer, callback) {
+
+  if (referrer.host && referrer.host.indexOf('search.yahoo.com') !== -1 &&
+      href.href.indexOf("utm_medium=cpc") !== -1) {
+    var description = { type: 'ad', network: 'yahoo' };
+    var query = querystring.parse(referrer.query).p;
+    if (query) description.query = query;
+    return callback(null, description);
+  } else {
+    return callback(null, false);
+  }
+
+};

--- a/lib/matchers/index.js
+++ b/lib/matchers/index.js
@@ -3,8 +3,10 @@
  * Priority fall through list of url matchers
  * @type {Array}
  */
-module.exports = [
+module.exports = [ 
+  require('./ad/bing'),
   require('./ad/google'),
+  require('./ad/yahoo'),
 
 	require('./social/facebook'),
 	require('./social/googlePlus'),

--- a/lib/matchers/index.js
+++ b/lib/matchers/index.js
@@ -4,6 +4,7 @@
  * @type {Array}
  */
 module.exports = [
+  require('./ad/google'),
 
 	require('./social/facebook'),
 	require('./social/googlePlus'),

--- a/test/cases/referrers.json
+++ b/test/cases/referrers.json
@@ -401,5 +401,24 @@
 				"link": "http://www.nytimes.com/2012/12/23/us/mixed-reaction-to-call-for-armed-guards-in-schools.html?_r=0"
 			}
 		}
+	},
+	
+	{
+		"url": "http://www.wix.com/html5webbuilder/400?utm_source=google&utm_medium=cpc&utm_campaign=campaign&experiment_id=website^e^19781277423^1t1",
+		"referrer": "http://www.google.com/aclk?sa=l&ai=CsDFiIh9XUarABMvj6QHT0YGIBsfH_88Dv_bU_kn5k94GCAAQASgDUJDJ9Pb9_____wFgya6RiYikgBCgAZv_4_ADyAEBqgQoT9BFkNuIRTPl4hEXKRYEjwVv-qNBF2bW-ACWbWogoTsqdyq5AEvnm4AHzYCcDw&sig=AOD64_2m2H4pZxoNx02zUamBzdK_jJjxtg&ved=0CC4Q0Qw&adurl=http://www.wix.com/html5webbuilder/400%3Futm_source%3Dgoogle%26utm_medium%3Dcpc%26utm_campaign%3Dcampaign%26experiment_id%3Dwebsite%5Ee%5E19781277423%5E1t1&rct=j&q=website",
+		"result": {
+			"referrer": {
+				"type": "ad",
+				"client": "google",
+				"from": "http://www.google.com/aclk?sa=l&ai=CsDFiIh9XUarABMvj6QHT0YGIBsfH_88Dv_bU_kn5k94GCAAQASgDUJDJ9Pb9_____wFgya6RiYikgBCgAZv_4_ADyAEBqgQoT9BFkNuIRTPl4hEXKRYEjwVv-qNBF2bW-ACWbWogoTsqdyq5AEvnm4AHzYCcDw&sig=AOD64_2m2H4pZxoNx02zUamBzdK_jJjxtg&ved=0CC4Q0Qw&adurl=http://www.wix.com/html5webbuilder/400%3Futm_source%3Dgoogle%26utm_medium%3Dcpc%26utm_campaign%3Dcampaign%26experiment_id%3Dwebsite%5Ee%5E19781277423%5E1t1&rct=j&q=website",
+				"link": "http://www.wix.com/html5webbuilder/400?utm_source=google&utm_medium=cpc&utm_campaign=campaign&experiment_id=website^e^19781277423^1t1",
+				"query": "website"
+			},
+			"campaign": {
+				"source": "google",
+				"medium": "cpc",
+				"campaign": "campaign"
+			}
+		}
 	}
 ]

--- a/test/cases/referrers.json
+++ b/test/cases/referrers.json
@@ -402,22 +402,53 @@
 			}
 		}
 	},
-	
 	{
 		"url": "http://www.wix.com/html5webbuilder/400?utm_source=google&utm_medium=cpc&utm_campaign=campaign&experiment_id=website^e^19781277423^1t1",
 		"referrer": "http://www.google.com/aclk?sa=l&ai=CsDFiIh9XUarABMvj6QHT0YGIBsfH_88Dv_bU_kn5k94GCAAQASgDUJDJ9Pb9_____wFgya6RiYikgBCgAZv_4_ADyAEBqgQoT9BFkNuIRTPl4hEXKRYEjwVv-qNBF2bW-ACWbWogoTsqdyq5AEvnm4AHzYCcDw&sig=AOD64_2m2H4pZxoNx02zUamBzdK_jJjxtg&ved=0CC4Q0Qw&adurl=http://www.wix.com/html5webbuilder/400%3Futm_source%3Dgoogle%26utm_medium%3Dcpc%26utm_campaign%3Dcampaign%26experiment_id%3Dwebsite%5Ee%5E19781277423%5E1t1&rct=j&q=website",
 		"result": {
 			"referrer": {
 				"type": "ad",
-				"client": "google",
-				"from": "http://www.google.com/aclk?sa=l&ai=CsDFiIh9XUarABMvj6QHT0YGIBsfH_88Dv_bU_kn5k94GCAAQASgDUJDJ9Pb9_____wFgya6RiYikgBCgAZv_4_ADyAEBqgQoT9BFkNuIRTPl4hEXKRYEjwVv-qNBF2bW-ACWbWogoTsqdyq5AEvnm4AHzYCcDw&sig=AOD64_2m2H4pZxoNx02zUamBzdK_jJjxtg&ved=0CC4Q0Qw&adurl=http://www.wix.com/html5webbuilder/400%3Futm_source%3Dgoogle%26utm_medium%3Dcpc%26utm_campaign%3Dcampaign%26experiment_id%3Dwebsite%5Ee%5E19781277423%5E1t1&rct=j&q=website",
-				"link": "http://www.wix.com/html5webbuilder/400?utm_source=google&utm_medium=cpc&utm_campaign=campaign&experiment_id=website^e^19781277423^1t1",
+				"network": "google",
 				"query": "website"
 			},
 			"campaign": {
 				"source": "google",
 				"medium": "cpc",
 				"campaign": "campaign"
+			}
+		}
+	},
+	{
+		"url": "https://www.godaddy.com/hosting/website-builder.aspx?isc=wb1db002&utm_source=MSN&utm_medium=cpc&utm_term=create%20your%20own%20website&utm_content=2042012586&utm_campaign=11438627325&ef_id=tedO1uxdk1gAAAzl:20130330174459:s",
+		"referrer": "http://search.yahoo.com/search;_ylt=AphWIR0PcVHjVBdrcBiSd.SbvZx4?p=website&toggle=1&cop=mss&ei=UTF-8&fr=yfp-t-900",
+		"result": {
+			"referrer": {
+				"type": "ad",
+				"network": "yahoo",
+				"query": "website"
+			},
+			"campaign": { 
+				"campaign": "11438627325",
+				"source": "MSN",
+				"term": "create your own website",
+				"medium": "cpc" 
+			}
+		}
+	},
+	{
+		"url": "http://www.godaddy.com/domains/search-dus.aspx?isc=gofab002&utm_source=MSN&utm_medium=cpc&utm_term=buying%20domain%20names&utm_content=1567759293&utm_campaign=11438627038&ef_id=tedO1uxdk1gAAAzl:20130330174553:s",
+		"referrer": "http://www.bing.com/search?q=website&go=&qs=n&form=QBLH&pq=website&sc=8-4&sp=-1&sk=",
+		"result": {
+			"referrer": {
+				"type": "ad",
+				"network": "bing",
+				"query": "website"
+			},
+			"campaign": {
+				"campaign": "11438627038",
+				"source": "MSN",
+				"term": "buying domain names",
+				"medium": "cpc"
 			}
 		}
 	}


### PR DESCRIPTION
This pull request includes basic support for search ads on Google, Bing, and Yahoo, with search term and campaign data. Plus fresh hot test-cases and minor doc update.

I suppose we could also have listed these as still being from the search type but with the extra campaign info as the marker they came from ads. But I'd like to adjust the matchers to eventually include non-search ads through the same networks, so this looks right to me.

Thanks for the library! We're looking to add a lot more sources to it so more pull requests to come if you are interested.

Thanks! -Adam
