### PR TITLE
Support all tlds for multi-tld providers

### DIFF
--- a/lib/matchers/email/yahoo.js
+++ b/lib/matchers/email/yahoo.js
@@ -1,16 +1,22 @@
-
+var tldextract = require("tldextract");
 
 module.exports = function (href, referrer, callback) {
 
-  if (referrer.host && referrer.host.indexOf('mail.yahoo.net') !== -1) {
-    return callback(null, {
-      type: 'email',
-      client: 'yahoo',
-      from: referrer.href,
-      link: href.href
-    });
-  } else {
+  if (referrer.host && referrer.host.indexOf('mail.yahoo') === -1) {
     return callback(null, false);
   }
+  
+  tldextract(referrer.href, function(e, tld) {
+    if (!e && tld.domain === "yahoo" && tld.subdomain.indexOf("mail") !== -1) {
+      return callback(null, {
+        type: 'email',
+        client: 'yahoo',
+        from: referrer.href,
+        link: href.href
+      });
+    } else {
+      return callback(null, false);
+    }
+  });
 
 };

--- a/lib/matchers/search/yahoo.js
+++ b/lib/matchers/search/yahoo.js
@@ -1,15 +1,22 @@
 
 var querystring = require('querystring');
+var tldextract = require('tldextract');
 
 module.exports = function (href, referrer, callback) {
 
-  if (referrer.host && referrer.host.indexOf('search.yahoo.com') !== -1) {
-    var description = { type: 'search', engine: 'yahoo' };
-    var query = querystring.parse(referrer.query).p;
-    if (query) description.query = query;
-    return callback(null, description);
-  } else {
+  if (referrer.host && referrer.host.indexOf('search.yahoo') === -1) {
     return callback(null, false);
   }
+  
+  tldextract(referrer.href, function(e, tld) {
+    if (!e && tld.domain === "yahoo" && tld.subdomain.indexOf("search") !== -1) {
+      var description = { type: 'search', engine: 'yahoo' };
+      var query = querystring.parse(referrer.query).p;
+      if (query) description.query = query;
+      return callback(null, description);
+    } else {
+      return callback(null, false);
+    }
+  });
 
 };

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   , "dependencies":{
       "underscore": "*"
     , "async": "*"
+    , "tldextract": "*"
   }
   , "devDependencies": {
       "should": "*"

--- a/test/cases/referrers.json
+++ b/test/cases/referrers.json
@@ -125,6 +125,17 @@
 		}
 	},
 	{
+		"url": null,
+		"referrer": "http://search.yahoo.co.jp/search?p=hello+how+are+you&search.x=1&fr=top_ga1_sa&tid=top_ga1_sa&ei=UTF-8&aq=&oq=web",
+		"result": {
+			"referrer": {
+				"type": "search",
+				"engine": "yahoo",
+				"query": "hello how are you"
+			}
+		}
+	},
+	{
 		"url": "http://blog.intercom.io/churn-retention-and-reengaging-customers/?utm_source=feedburner&utm_medium=feed&utm_campaign=Feed%3A+contrast%2Fblog+%28The+Intercom+Blog%29",
 		"referrer": "http://hypem.com/blog/indie+rock+cafe/12289",
 		"result": {
@@ -197,6 +208,18 @@
 				"type": "email",
 				"client": "yahoo",
 				"from": "http://36ohk6dgmcd1n-c.c.yom.mail.yahoo.net/om/api/1.0/openmail.app.invoke/36ohk6dgmcd1n/11/1.0.35/us_bizmail/en-US/view.html/0",
+				"link": "https://www.boutine.com/home"
+			}
+		}
+	},
+	{
+		"url": "https://www.boutine.com/home",
+		"referrer": "http://36ohk6dgmcd1n-c.c.yom.mail.yahoo.co.jp/om/api/1.0/openmail.app.invoke/36ohk6dgmcd1n/11/1.0.35/us_bizmail/en-US/view.html/0",
+		"result": {
+			"referrer": {
+				"type": "email",
+				"client": "yahoo",
+				"from": "http://36ohk6dgmcd1n-c.c.yom.mail.yahoo.co.jp/om/api/1.0/openmail.app.invoke/36ohk6dgmcd1n/11/1.0.35/us_bizmail/en-US/view.html/0",
 				"link": "https://www.boutine.com/home"
 			}
 		}


### PR DESCRIPTION
The existing matchers either directly search for a .com url or look for a sld by trying to match a string in the hostname. I would like to add automatic support for matching a given sld under all its tlds. This pull request currently demonstrates one way to do this for yahoo properties.

_Why?_

While some services (e.g. Twitter) seem to always be hosted at a .com, regardless of the user's language, most web properties are hosted on multiple tlds. Yahoo is at search.yahoo.com and search.yahoo.co.jp. The easiest way to match this is to do a substring search: `referrer.host.indexOf("search.yahoo")`. But this is potentially misleading, if there is ever a hostname like "search.yahoo.somethingelse.com". So instead, we need to actually parse apart the tld, sld, and subdomains, and look for exact matches against those. 

_Why not?_

The tldextract npm module that this requires takes a long time to start up, because it has to load all extent tlds from a text file. On my machine, just adding this dependency changes the tests from running in 50ms to taking nearly a second. But this appears to be almost all a startup cost: it adds very little to each subsequent query. So it's probably worth it if you want more accurate data and do this often enough to spread the startup cost among lots of hits.

_What's next?_

If this seems like a good idea, I would like to add the tld parsing to the parsedHref and parsedReferrer passed into every matcher so that it is easier to use. Then I can migrate matchers on multi-tld properties to use this rather than string lookups.
