### PR TITLE
Fix unsafe uses of referrer 'path'

### DIFF
--- a/lib/matchers/ad/google.js
+++ b/lib/matchers/ad/google.js
@@ -2,7 +2,8 @@ var querystring = require("querystring");
 
 module.exports = function (href, referrer, callback) {
 
-  if (referrer.host && 
+  if (referrer.host &&
+      referrer.path &&
       referrer.path.indexOf("/aclk") !== -1 &&
       (referrer.host.indexOf('google') !== -1 ||
        referrer.host.indexOf('googleadservices.com') !== -1)) {

--- a/lib/matchers/direct/direct.js
+++ b/lib/matchers/direct/direct.js
@@ -8,6 +8,6 @@
  */
 module.exports = function (href, referrer, callback) {
 
-	if (!referrer.href) return callback(null, {type: 'direct'});
+	if (!referrer.href || (referrer.protocol && referrer.protocol == 'about:')) return callback(null, {type: 'direct'});
   else return callback(null, false);
 };

--- a/lib/matchers/link/link.js
+++ b/lib/matchers/link/link.js
@@ -3,7 +3,7 @@
 module.exports = function (href, referrer, callback) {
 
   // if the link has a valid host and link then its a link
-  if (referrer.host && referrer.href) {
+  if (referrer.host && referrer.href && (!referrer.protocol || referrer.protocol != 'about:')) {
     return callback(null, {
       type: 'link',
       from: referrer.href,

--- a/lib/matchers/local/bing.js
+++ b/lib/matchers/local/bing.js
@@ -3,8 +3,10 @@ var querystring = require('querystring');
 
 module.exports = function (href, referrer, callback) {
 
-  if (referrer.host && referrer.host.indexOf('bing.com') !== -1
-      && referrer.path.indexOf("/local") === 0) {
+  if (referrer.host && 
+      referrer.host.indexOf('bing.com') !== -1 &&
+      referrer.path &&
+      referrer.path.indexOf("/local") === 0) {
     var description = { type: 'local', site: 'bing' };
     var query = querystring.parse(referrer.query).q;
     if (query) description.query = query;

--- a/lib/matchers/social/pinterest.js
+++ b/lib/matchers/social/pinterest.js
@@ -11,10 +11,12 @@ module.exports = function (href, referrer, callback) {
       network: 'pinterest'
     };
 
-    var tokens = referrer.path.split('/');
-    var index = _.indexOf(tokens, 'pin');
-    if (index !== -1) {
-      description.pin = tokens[index + 1];
+    if (referrer.path) {
+      var tokens = referrer.path.split('/');
+      var index = _.indexOf(tokens, 'pin');
+      if (index !== -1) {
+        description.pin = tokens[index + 1];
+      }
     }
   }
 

--- a/test/cases/referrers.json
+++ b/test/cases/referrers.json
@@ -658,5 +658,14 @@
 				"medium": "cpc"
 			}
 		}
+	},
+	{
+		"url": null,
+		"referrer": "about:blank",
+		"result": {
+			"referrer": {
+				"type": "direct"
+			}
+		}
 	}
 ]


### PR DESCRIPTION
It's not safe to assume all referrer's will have a path.  There may be a better way to fix this at a high level (like when we parse the url) but this is the fix I'm currently using to workaround some errors.
